### PR TITLE
Update todo.test.js to resolve handling the file name which has space-seperated arguments

### DIFF
--- a/shared/todo.test.js
+++ b/shared/todo.test.js
@@ -12,7 +12,7 @@ beforeEach(() => {
   deleteFile(`${__dirname}/done.txt`);
 });
 
-let todoTxtCli = (...args) => [`${__dirname}/todo`, ...args].join(" ");
+let todoTxtCli = (...args) => [`${__dirname.replace(/ /g,"^ ")}/todo`, ...args].join(" ");
 
 let usage = `Usage :-
 $ ./todo add "todo item"  # Add a new todo


### PR DESCRIPTION
child_process package was unable to resolve directory paths which are space-separated arguments as folder names. Fixed the issue by replacing the path or spaces with caret symbol (^) after fetching the current directory path 